### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -45,6 +45,7 @@ my $builder = $class->new(
 		'Test::Exception'                => 0,
 		'Test::FailWarnings'             => 0,
 		'Test::Git'                      => 0,
+		'Test::Requires::Git'            => 1.005,
 		'Test::More'                     => 0,
 	},
 	requires            =>

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,7 @@ WriteMakefile
   'VERSION_FROM' => 'lib/Perl/Critic/Git.pm',
   'PREREQ_PM' => {
                    'Test::Git' => 0,
+                   'Test::Requires::Git' => 1.005,
                    'Test::Exception' => 0,
                    'Test::FailWarnings' => 0,
                    'Data::Dumper' => 0,

--- a/t/01-setup.t
+++ b/t/01-setup.t
@@ -9,11 +9,12 @@ use Git::Repository ( 'Log' );
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
 use Test::Git;
+use Test::Requires::Git
 use Test::More;
 
 
 # Check there is a git binary available, or skip all.
-has_git();
+test_requires_git();
 plan( tests => 12 );
 
 # Create a new, empty repository in a temporary location and return

--- a/t/10-new.t
+++ b/t/10-new.t
@@ -8,12 +8,12 @@ use warnings;
 use Perl::Critic::Git;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Check there is a git binary available, or skip all.
-has_git();
+test_requires_git();
 plan( tests => 8 );
 
 # Retrieve the path to the test git repository.

--- a/t/15-_get_file.t
+++ b/t/15-_get_file.t
@@ -8,12 +8,12 @@ use warnings;
 use Perl::Critic::Git;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Check there is a git binary available, or skip all.
-has_git();
+test_requires_git();
 plan( tests => 4 );
 
 # Retrieve the path to the test git repository.

--- a/t/20-get_authors.t
+++ b/t/20-get_authors.t
@@ -9,12 +9,12 @@ use Perl::Critic::Git;
 use Test::Deep;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Check there is a git binary available, or skip all.
-has_git();
+test_requires_git();
 plan( tests => 6 );
 
 # Retrieve the path to the test git repository.

--- a/t/30-report_violations.t
+++ b/t/30-report_violations.t
@@ -9,12 +9,12 @@ use Perl::Critic::Git;
 use Test::Deep;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Check there is a git binary available, or skip all.
-has_git();
+test_requires_git();
 plan( tests => 9 );
 
 # Retrieve the path to the test git repository.

--- a/t/40-_is_analyzed.t
+++ b/t/40-_is_analyzed.t
@@ -8,12 +8,12 @@ use warnings;
 use Perl::Critic::Git;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Check there is a git binary available, or skip all.
-has_git();
+test_requires_git();
 plan( tests => 6 );
 
 # Retrieve the path to the test git repository.

--- a/t/41-force_reanalyzing.t
+++ b/t/41-force_reanalyzing.t
@@ -8,12 +8,12 @@ use warnings;
 use Perl::Critic::Git;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Check there is a git binary available, or skip all.
-has_git();
+test_requires_git();
 plan( tests => 7 );
 
 # Retrieve the path to the test git repository.

--- a/t/50-get_perlcritic_violations.t
+++ b/t/50-get_perlcritic_violations.t
@@ -9,12 +9,12 @@ use Data::Dumper;
 use Perl::Critic::Git;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Check there is a git binary available, or skip all.
-has_git();
+test_requires_git();
 plan( tests => 8 );
 
 # Retrieve the path to the test git repository.

--- a/t/60-get_blame_lines.t
+++ b/t/60-get_blame_lines.t
@@ -9,12 +9,12 @@ use Data::Dumper;
 use Perl::Critic::Git;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Check there is a git binary available, or skip all.
-has_git();
+test_requires_git();
 plan( tests => 7 );
 
 # Retrieve the path to the test git repository.

--- a/t/61-get_blame_line.t
+++ b/t/61-get_blame_line.t
@@ -9,12 +9,12 @@ use Data::Dumper;
 use Perl::Critic::Git;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Check there is a git binary available, or skip all.
-has_git();
+test_requires_git();
 plan( tests => 7 );
 
 # Retrieve the path to the test git repository.

--- a/t/99-cleanup.t
+++ b/t/99-cleanup.t
@@ -8,12 +8,12 @@ use warnings;
 use File::Path qw();
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Check there is a git binary available, or skip all.
-has_git();
+test_requires_git();
 plan( tests => 7 );
 
 # Retrieve the path to the test git repository.


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.